### PR TITLE
Refs #249 #250, namespace letsencrypt issuer

### DIFF
--- a/osm-seed/templates/jobs/populate-apidb-job.yaml
+++ b/osm-seed/templates/jobs/populate-apidb-job.yaml
@@ -9,39 +9,39 @@ metadata:
     environment: {{ .Values.environment }}
     release: {{ .Release.Name }}
 spec:
-    template:
-      spec:
-        containers:
-        - name: {{ .Release.Name }}-populate-apidb-job
-          image: {{ .Values.populateApidb.image.name }}:{{ .Values.populateApidb.image.tag }}
-          command: ['/start.sh']
-          {{- if .Values.populateApidb.resources.enabled }}   
-          resources:
-            requests:
-              memory: {{ .Values.populateApidb.resources.requests.memory }}
-              cpu: {{ .Values.populateApidb.resources.requests.cpu }}
-            limits:
-              memory: {{ .Values.populateApidb.resources.limits.memory }}
-              cpu: {{ .Values.populateApidb.resources.limits.cpu }}
-          {{- end }}
-          env:
-            - name: POSTGRES_HOST
-              value: {{ .Release.Name }}-db
-            - name: POSTGRES_DB
-              value: {{ .Values.db.env.POSTGRES_DB }}
-            - name: POSTGRES_PASSWORD
-              value: {{ quote .Values.db.env.POSTGRES_PASSWORD }}
-            - name: POSTGRES_USER
-              value: {{ .Values.db.env.POSTGRES_USER }}
-            - name: URL_FILE_TO_IMPORT
-              value: {{.Values.populateApidb.env.URL_FILE_TO_IMPORT}}
-            {{- if .Values.populateApidb.resources.enabled }}   
-            - name: MEMORY_JAVACMD_OPTIONS
-              value: {{ .Values.populateApidb.resources.requests.memory  | default "4Gi" | quote}}
-            {{- end }}
-        restartPolicy: Never
-        {{- if .Values.populateApidb.nodeSelector.enabled }}
-        nodeSelector:
-          {{ .Values.populateApidb.nodeSelector.label_key }} : {{ .Values.populateApidb.nodeSelector.label_value }}
+  template:
+    spec:
+      containers:
+      - name: {{ .Release.Name }}-populate-apidb-job
+        image: "{{ .Values.populateApidb.image.name }}:{{ .Values.populateApidb.image.tag }}"
+        command: ['/start.sh']
+        {{- if .Values.populateApidb.resources.enabled }}   
+        resources:
+          requests:
+            memory: {{ .Values.populateApidb.resources.requests.memory }}
+            cpu: {{ .Values.populateApidb.resources.requests.cpu }}
+          limits:
+            memory: {{ .Values.populateApidb.resources.limits.memory }}
+            cpu: {{ .Values.populateApidb.resources.limits.cpu }}
         {{- end }}
+        env:
+          - name: POSTGRES_HOST
+            value: {{ .Release.Name }}-db
+          - name: POSTGRES_DB
+            value: {{ .Values.db.env.POSTGRES_DB }}
+          - name: POSTGRES_PASSWORD
+            value: {{ quote .Values.db.env.POSTGRES_PASSWORD }}
+          - name: POSTGRES_USER
+            value: {{ .Values.db.env.POSTGRES_USER }}
+          - name: URL_FILE_TO_IMPORT
+            value: {{.Values.populateApidb.env.URL_FILE_TO_IMPORT}}
+          {{- if .Values.populateApidb.resources.enabled }}   
+          - name: MEMORY_JAVACMD_OPTIONS
+            value: {{ .Values.populateApidb.resources.requests.memory  | default "4Gi" | quote}}
+          {{- end }}
+      restartPolicy: Never
+      {{- if .Values.populateApidb.nodeSelector.enabled }}
+      nodeSelector:
+        {{ .Values.populateApidb.nodeSelector.label_key }} : {{ .Values.populateApidb.nodeSelector.label_value }}
+      {{- end }}
 {{- end }}

--- a/osm-seed/templates/letsencrypt-issuer.yaml
+++ b/osm-seed/templates/letsencrypt-issuer.yaml
@@ -2,7 +2,7 @@
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-    name: letsencrypt-prod-issuer
+    name: {{ template ".Release.Name" . }}-letsencrypt-prod-issuer
 spec:
     acme:
         # You must replace this email address with your own.

--- a/osm-seed/templates/letsencrypt-issuer.yaml
+++ b/osm-seed/templates/letsencrypt-issuer.yaml
@@ -2,7 +2,7 @@
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-    name: {{ template ".Release.Name" . }}-letsencrypt-prod-issuer
+    name: {{ .Release.Name }}-letsencrypt-prod-issuer
 spec:
     acme:
         # You must replace this email address with your own.

--- a/osm-seed/templates/nominatim-api/nominatim-api-ingress.yaml
+++ b/osm-seed/templates/nominatim-api/nominatim-api-ingress.yaml
@@ -5,8 +5,7 @@ metadata:
   name: {{ template "osm-seed.fullname" . }}-ingress-nominatim-api
   annotations:
     kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod-issuer
-spec:
+    cert-manager.io/cluster-issuer: {{ template ".Release.Name" . }}-letsencrypt-prod-issuer
   tls:
     - hosts:
       - nominatim.{{ .Values.domain }}

--- a/osm-seed/templates/nominatim-api/nominatim-api-ingress.yaml
+++ b/osm-seed/templates/nominatim-api/nominatim-api-ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: {{ .Release.Name }}-letsencrypt-prod-issuer
+spec:
   tls:
     - hosts:
       - nominatim.{{ .Values.domain }}

--- a/osm-seed/templates/nominatim-api/nominatim-api-ingress.yaml
+++ b/osm-seed/templates/nominatim-api/nominatim-api-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "osm-seed.fullname" . }}-ingress-nominatim-api
   annotations:
     kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: {{ template ".Release.Name" . }}-letsencrypt-prod-issuer
+    cert-manager.io/cluster-issuer: {{ .Release.Name }}-letsencrypt-prod-issuer
   tls:
     - hosts:
       - nominatim.{{ .Values.domain }}

--- a/osm-seed/templates/overpass-api/overpass-api-ingress.yaml
+++ b/osm-seed/templates/overpass-api/overpass-api-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "osm-seed.fullname" . }}-ingress-overpass-api
   annotations:
     kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod-issuer
+    cert-manager.io/cluster-issuer: {{ template ".Release.Name" . }}-letsencrypt-prod-issuer
 spec:
   tls:
     - hosts:

--- a/osm-seed/templates/overpass-api/overpass-api-ingress.yaml
+++ b/osm-seed/templates/overpass-api/overpass-api-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "osm-seed.fullname" . }}-ingress-overpass-api
   annotations:
     kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: {{ template ".Release.Name" . }}-letsencrypt-prod-issuer
+    cert-manager.io/cluster-issuer: {{ .Release.Name }}-letsencrypt-prod-issuer
 spec:
   tls:
     - hosts:

--- a/osm-seed/templates/taginfo/taginfo-ingress.yaml
+++ b/osm-seed/templates/taginfo/taginfo-ingress.yaml
@@ -5,8 +5,7 @@ metadata:
   name: {{ template "osm-seed.fullname" . }}-ingress-taginfo-api
   annotations:
     kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod-issuer
-spec:
+    cert-manager.io/cluster-issuer: {{ template ".Release.Name" . }}-letsencrypt-prod-issuer
   tls:
     - hosts:
       - taginfo.{{ .Values.domain }}

--- a/osm-seed/templates/taginfo/taginfo-ingress.yaml
+++ b/osm-seed/templates/taginfo/taginfo-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "osm-seed.fullname" . }}-ingress-taginfo-api
   annotations:
     kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: {{ template ".Release.Name" . }}-letsencrypt-prod-issuer
+    cert-manager.io/cluster-issuer: {{ .Release.Name }}-letsencrypt-prod-issuer
   tls:
     - hosts:
       - taginfo.{{ .Values.domain }}

--- a/osm-seed/templates/tasking-manager-api/tasking-manager-api-ingress.yaml
+++ b/osm-seed/templates/tasking-manager-api/tasking-manager-api-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "osm-seed.fullname" . }}-ingress-tm-api
   annotations:
     kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: {{ template ".Release.Name" . }}-letsencrypt-prod-issuer
+    cert-manager.io/cluster-issuer: {{ .Release.Name }}-letsencrypt-prod-issuer
 spec:
   tls:
     - hosts:

--- a/osm-seed/templates/tasking-manager-api/tasking-manager-api-ingress.yaml
+++ b/osm-seed/templates/tasking-manager-api/tasking-manager-api-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "osm-seed.fullname" . }}-ingress-tm-api
   annotations:
     kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod-issuer
+    cert-manager.io/cluster-issuer: {{ template ".Release.Name" . }}-letsencrypt-prod-issuer
 spec:
   tls:
     - hosts:

--- a/osm-seed/templates/tiler-server/tiler-server-ingress.yaml
+++ b/osm-seed/templates/tiler-server/tiler-server-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "osm-seed.fullname" . }}-ingress-tiler-server
   annotations:
     kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: {{ template ".Release.Name" . }}-letsencrypt-prod-issuer
+    cert-manager.io/cluster-issuer: {{ .Release.Name }}-letsencrypt-prod-issuer
 spec:
   tls:
     - hosts:

--- a/osm-seed/templates/tiler-server/tiler-server-ingress.yaml
+++ b/osm-seed/templates/tiler-server/tiler-server-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "osm-seed.fullname" . }}-ingress-tiler-server
   annotations:
     kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod-issuer
+    cert-manager.io/cluster-issuer: {{ template ".Release.Name" . }}-letsencrypt-prod-issuer
 spec:
   tls:
     - hosts:

--- a/osm-seed/templates/tiler-visor/tiler-visor-ingress.yaml
+++ b/osm-seed/templates/tiler-visor/tiler-visor-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "osm-seed.fullname" . }}-ingress-tiler-visor
   annotations:
     kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: {{ template ".Release.Name" . }}-letsencrypt-prod-issuer
+    cert-manager.io/cluster-issuer: {{ .Release.Name }}-letsencrypt-prod-issuer
 spec:
   tls:
     - hosts:

--- a/osm-seed/templates/tiler-visor/tiler-visor-ingress.yaml
+++ b/osm-seed/templates/tiler-visor/tiler-visor-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "osm-seed.fullname" . }}-ingress-tiler-visor
   annotations:
     kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod-issuer
+    cert-manager.io/cluster-issuer: {{ template ".Release.Name" . }}-letsencrypt-prod-issuer
 spec:
   tls:
     - hosts:

--- a/osm-seed/templates/web/web-ingress.yaml
+++ b/osm-seed/templates/web/web-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "osm-seed.fullname" . }}-ingress-web
   annotations:
     kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: {{ template ".Release.Name" . }}-letsencrypt-prod-issuer
+    cert-manager.io/cluster-issuer: {{ .Release.Name }}-letsencrypt-prod-issuer
 spec:
   tls:
     - hosts:

--- a/osm-seed/templates/web/web-ingress.yaml
+++ b/osm-seed/templates/web/web-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "osm-seed.fullname" . }}-ingress-web
   annotations:
     kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod-issuer
+    cert-manager.io/cluster-issuer: {{ template ".Release.Name" . }}-letsencrypt-prod-issuer
 spec:
   tls:
     - hosts:

--- a/osm-seed/values.yaml
+++ b/osm-seed/values.yaml
@@ -275,7 +275,10 @@ populateApidb:
     limits:
       memory: '2Gi'
       cpu: '2.5'
-
+  nodeSelector:
+    enabled: false
+    label_key: nodegroup_type
+    label_value: tiler
 # ====================================================================================================
 # Variables to start a pod to process osm files
 # ====================================================================================================


### PR DESCRIPTION
Thanks to @dakotabenjamin for the catch here over in #249 .

This just completes that PR, ensuring all the Ingress resources are using the correctly namespaced name for the Lets Encrypt Issuer.

Also thanks @yuvipanda !
