### PR TITLE
 Move backup-restore image to Debian bookworm

### DIFF
--- a/images/backup-restore/Dockerfile
+++ b/images/backup-restore/Dockerfile
@@ -1,17 +1,20 @@
-FROM python:3.9.9-slim
+FROM python:3.12-slim-bookworm
 
 # Install Postgres client 17 and ZSTD compression tools
 RUN apt-get update \
-    && apt-get install -y curl apt-transport-https lsb-release gnupg \
-    && echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
-    && curl -L https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+    && apt-get install -y --no-install-recommends curl ca-certificates gnupg lsb-release \
+    && install -d /usr/share/postgresql-common/pgdg \
+    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+       | gpg --dearmor -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg \
+    && echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg] http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main" \
+       > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
-    && apt-get install -y postgresql-client-17 wget zstd \
+    && apt-get install -y --no-install-recommends postgresql-client-17 wget zstd \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Install AWS CLI
-RUN pip install awscli
+RUN pip install --no-cache-dir awscli
 
 COPY ./start.sh /
 CMD ["/start.sh"]


### PR DESCRIPTION
The backup-restore image build was failing in CI. Its base image python:3.9.9-slim runs Debian 11 (bullseye), which reached end of life. The bullseye-security release file expired a few days ago, so apt-get update rejects it and the build stops.

This moves the image to python:3.12-slim-bookworm and the bookworm-pgdg Postgres repo. It also replaces the deprecated apt-key with a signed-by keyring. Built and tested locally: pg_dump 17.11, zstd, and aws-cli all work.
