### PR TITLE
Remove unused apt packages from tiler-db image

### DIFF
--- a/images/tiler-db/Dockerfile
+++ b/images/tiler-db/Dockerfile
@@ -1,6 +1,4 @@
 FROM postgis/postgis:14-3.4
-RUN apt-get update
-RUN apt-get install -y git ca-certificates
 
 COPY ./config/docker-entrypoint.sh /usr/local/bin/
 RUN mkdir -p /docker-entrypoint-initdb.d


### PR DESCRIPTION
The tiler-db image build was failing in CI. Its base image postgis/postgis:14-3.4 runs Debian 11 (bullseye), whose security repo expired, so apt-get update stops the build.